### PR TITLE
Improved URL handling, handling of erroneous DPI parsing

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,16 @@ def parse_url_to_chapter_info(url):
     url = re.sub("http://", '', url)
     url = re.sub("mangapark.me", '', url)
     url = re.sub("/manga/", '', url)
-    title, _, version, chapter = url.split("/")
+
+    # compensate for mangapark's different url formatting schemes
+    title, version, chapter = None, None, None
+    if len(url.split("/")) == 3:
+        title, version, chapter = url.split("/")
+    elif len(url.split("/")):
+        title, _, version, chapter = url.split("/")
+    else:
+        raise ValueError("Couldn't parse URL")
+
     return title, version, chapter, url
 
 


### PR DESCRIPTION
First of all my I wanted to issue an excuse for my last patch.  Apparently mangapark uses two *different* URL formats.  As the three manga series I tested my last contribution with all used the other format, I assumed that it was the default for every series.  This patch fixes this behavior.

Another issue addressed in this patch is that for some of the images hosted on mangapark the DPI is not recognized properly (and subsequently read as 1).  Because PDFs page size is limited by 200*200 inches, this lead to an exception.  Commit da30354654c5f83f1c8f9a59754ba40daa78b7e8 lets img2pdf default to a page height of 7" if the DPI information could not be read.

I furthermore took the freedom to comment the code.