### PR TITLE
Fix/ur get

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,7 +82,7 @@ def download_chapter(url, height):
 def rezise(filename, height):
     if height == None:
         return filename
-    print("Resizing %s to %s..." % (filename, height))
+    print("Resizing %s to %spx height..." % (filename, height))
     with open(filename, 'r+b') as f:
         with Image.open(f) as image:
             cover = resizeimage.resize_height(image, height)

--- a/main.py
+++ b/main.py
@@ -75,7 +75,6 @@ def download_chapter(url, height):
         dir_filename = os_dir + "/" + os.path.basename(img_url)
         urllib.request.urlretrieve(img_url, dir_filename)
         new_dir_filename = rezise(dir_filename, height)
-        print(">>>>>>>>>>> %s" % new_dir_filename);
         filenames.append(new_dir_filename)
 
     convert_to_pdf(os_dir, chapter, filenames)

--- a/main.py
+++ b/main.py
@@ -130,12 +130,12 @@ def download_chapter(url: str, height: int) -> None:
         print("Downloading %s %s %s..." % (title, chapter, filename))
         dir_filename = os_dir + "/" + os.path.basename(img_url)
         urllib.request.urlretrieve(img_url, dir_filename)
-        new_dir_filename = rezise(dir_filename, height)
+        new_dir_filename = resize(dir_filename, height)
         filenames.append(new_dir_filename)
 
     convert_to_pdf(os_dir, chapter, filenames)
 
-def rezise(filename, height):
+def resize(filename: str, height: int) -> str:
     if height == None:
         return filename
     print("Resizing %s to %spx height..." % (filename, height))

--- a/main.py
+++ b/main.py
@@ -125,7 +125,7 @@ def download_chapter(url: str, height: int) -> None:
     imgs_wrappers = soup.find_all("a", {"class": "img-link"})
     filenames = []
     for i in imgs_wrappers:
-        img_url = i.img['src']
+        img_url = parse_url(i.img['src'])
         filename = img_url.split('/')[-1]
         print("Downloading %s %s %s..." % (title, chapter, filename))
         dir_filename = os_dir + "/" + os.path.basename(img_url)
@@ -134,6 +134,9 @@ def download_chapter(url: str, height: int) -> None:
         filenames.append(new_dir_filename)
 
     convert_to_pdf(os_dir, chapter, filenames)
+
+def parse_url(url: str) -> str:
+    return re.sub(r'\?.*', '', url)
 
 def resize(filename: str, height: int) -> str:
     if height == None:

--- a/readme.md
+++ b/readme.md
@@ -5,12 +5,15 @@ A script to download your favourite mangas on mangapark.me and convert them to .
 ## Instructions
 
 ```
-# Download chapter 20 for the manga Ajin Miura Tsuina
-$ python3 main.py -m http://mangapark.me/manga/ajin-miura-tsuina/ -chapter 20
+# Download chapter 20 for the manga Ajin Miura Tsuina 
+$ python3 main.py -m http://mangapark.me/manga/ajin-miura-tsuina/ -chapter 20 --size 1000
 
 # Download chapters 19 to 40 for the manga Ajin Miura Tsuina
-$ python3 main.py -m http://mangapark.me/manga/ajin-miura-tsuina/ -chapters 19 40
+$ python3 main.py -m http://mangapark.me/manga/ajin-miura-tsuina/ -chapters 19 40 --size 1000
 ```
+
+You can add the argument `--size` to both ways of downloading, to change the height of the downloaded images.
+_Sometimes the `img2pdf` will fail due to the size of the original downloaded images. I recommend `--size 1000`_
 
 ## Dependencies
 

--- a/readme.md
+++ b/readme.md
@@ -17,3 +17,4 @@ $ python3 main.py -m http://mangapark.me/manga/ajin-miura-tsuina/ -chapters 19 4
 - Python 3
 - img2pdf
 - BeautifulSoup4
+- python-resize-image

--- a/readme.md
+++ b/readme.md
@@ -8,11 +8,11 @@ A script to download your favourite mangas on mangapark.me and convert them to .
 # Download chapter 20 for the manga Ajin Miura Tsuina 
 $ python3 main.py -m http://mangapark.me/manga/ajin-miura-tsuina/ -chapter 20 --size 1000
 
-# Download chapters 19 to 40 for the manga Ajin Miura Tsuina
-$ python3 main.py -m http://mangapark.me/manga/ajin-miura-tsuina/ -chapters 19 40 --size 1000
+# Download chapters 19 to 22 for the manga Ajin Miura Tsuina very small
+$ python3 main.py -m http://mangapark.me/manga/ajin-miura-tsuina/ --chapters 19 22 --size 300
 ```
 
-You can add the argument `--size` to both ways of downloading, to change the height of the downloaded images.
+`--size` is optional on both ways of downloading. Without it, it will not resize.
 _Sometimes the `img2pdf` will fail due to the size of the original downloaded images. I recommend `--size 1000`_
 
 ## Dependencies


### PR DESCRIPTION
Merge after https://github.com/tohyongcheng/mangapark-dl/pull/5.

When I tried to download from: http://mangapark.me/manga/shingeki-no-kyojin/
I got:
```
Namespace(chapter='67', chapters=None, manga_url='http://mangapark.me/manga/shingeki-no-kyojin/', size=None)
Downloading shingeki-no-kyojin c67 1.jpg?1439195884...
Traceback (most recent call last):
File "main.py", line 208, in <module>
main()
File "main.py", line 204, in main
download_manga(args.manga_url, chapter=int(args.chapter), height=args.size)
File "main.py", line 180, in download_manga
download_chapter(chapter_url, height)
File "main.py", line 132, in download_chapter
urllib.request.urlretrieve(parse_url(img_url), dir_filename)
File "main.py", line 198, in urlretrieve
tfp = open(filename, 'wb')
OSError: [Errno 22] Invalid argument: 'shingeki-no-kyojin/s1/v17/c67/1.jpg?1439195884'
```
This fixes that